### PR TITLE
Don't collapse one line of code

### DIFF
--- a/collapse-test.md
+++ b/collapse-test.md
@@ -1,0 +1,33 @@
+Instead of connecting to a real backend API or web service, we’ll use [can-fixture fixtures]
+to “mock” an API. Whenever an [AJAX](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest)
+request is made, the fixture will “capture” the request and instead respond with mock data.
+
+> **Note:** if you open your browser’s Network panel, you will *not* see any network requests.
+> You can see the fixture requests and responses in your browser’s Console panel.
+
+How fixtures work is outside the scope of this tutorial and not necessary to understand to continue,
+but you can learn more in the [can-fixture] documentation.
+
+## Defining a custom element with CanJS
+
+We mentioned above that CanJS helps you define custom elements. We call these [can-component components].
+
+Add the following to the **JS** tab in your CodePen:
+
+```js
+// Creates a mock backend with 3 todos
+import { todoFixture } from "//unpkg.com/can-demo-models@5";
+todoFixture(3);
+
+import { Component } from "//unpkg.com/can@5/core.mjs";
+
+Component.extend({
+	tag: "todos-app",
+	view: `
+		<h1>Today’s to-dos</h1>
+	`,
+	ViewModel: {
+	}
+});
+```
+<span line-highlight='2-7,9-14,only'/>

--- a/index.js
+++ b/index.js
@@ -66,11 +66,14 @@ var getConfig = function(lineString, lineCount) {
 					return typeof val === 'number' && !isNaN(val);
 				})
 			;
-
+			
 			if (range[0] > current + padding) {
-				collapse.push(current + '-' + (range[0] - 1 - padding));
+				var collapseEnd = (range[0] - 1 - padding);
+				if (collapseEnd !== current) {
+					collapse.push(current + '-' + collapseEnd);
+				}
 			}
-
+			
 			current = (range[1] || range[0]) + padding + 1;
 		}
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prismjs": "^1.11.0"
   },
   "devDependencies": {
-    "bit-docs-generate-html": "^0.1.0",
+    "bit-docs-generate-html": "^0.15.0",
     "connect": "^2.14.4",
     "mocha": "^2.5.3",
     "zombie": "^4.3.0"

--- a/test.js
+++ b/test.js
@@ -58,4 +58,38 @@ describe("bit-docs-html-highlight-line", function() {
 			}, done);
 		}, done);
 	});
+
+	it("dosen't show expand button for one line code", function(done) {
+		this.timeout(60000);
+
+		var docMap = Promise.resolve({
+			index: {
+				name: "index",
+				demo: "path/to/demo.html",
+				body: fs.readFileSync(__dirname+"/collapse-test.md", "utf8")
+			}
+		});
+
+		generate(docMap, {
+			html: {
+				dependencies: {
+					"bit-docs-html-highlight-line": __dirname
+				}
+			},
+			dest: path.join(__dirname, "temp"),
+			parent: "index",
+			forceBuild: true,
+			debug: true,
+			minifyBuild: false
+		}).then(function() {
+			open("index.html",function(browser, close) {
+				var doc = browser.window.document;
+				var collapseCodes = doc.querySelectorAll('pre[data-collapse] code');
+				assert.equal(collapseCodes.length, 0);
+				close();
+				done();
+			}, done);
+		}, done)
+
+	});
 });


### PR DESCRIPTION
> This is needed by https://github.com/canjs/bit-docs-html-canjs/issues/556

This prevent collapsing one line of code, for example the following will not collapse line 1 and 8:

```html
// Creates a mock backend with 3 todos
import { todoFixture } from "//unpkg.com/can-demo-models@5";
todoFixture(3);

import { Component } from "//unpkg.com/can@5/core.mjs";

Component.extend({
	tag: "todos-app",
	view: `
		<h1>Today’s to-dos</h1>
	`,
	ViewModel: {
	}
});
<span line-highlight='2-7,9-14,only'/>
```
Fixes https://github.com/canjs/bit-docs-html-canjs/issues/556