### PR TITLE
only one line after expand button

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ module.exports = function() {
 		//Without trimming, additional characters can create new lines
 		//this happens when PrismJS is not applied (in testing)
 		//setting total to length - 1 makes the last not collapsed
-		var total = codeBlock.innerHTML.trim().split('\n').length;
+		var total = codeBlock.innerHTML.split('\n').length;
 		var config = getConfig(highlight.getAttribute('line-highlight'), total);
 
 		if (preBlock) {

--- a/index.js
+++ b/index.js
@@ -109,9 +109,7 @@ module.exports = function() {
 		//Without trimming, additional characters can create new lines
 		//this happens when PrismJS is not applied (in testing)
 		//setting total to length - 1 makes the last not collapsed
-		if (codeBlock.textContent.slice(-1) === "\n") {
-			codeBlock.textContent = codeBlock.textContent.slice(0, -1);
-		}
+		codeBlock.textContent = codeBlock.textContent.trim();
 		var total = codeBlock.innerHTML.split('\n').length;
 		var config = getConfig(highlight.getAttribute('line-highlight'), total);
 

--- a/index.js
+++ b/index.js
@@ -106,8 +106,10 @@ module.exports = function() {
 
 		var preBlock = findPreviousSibling(highlight.parentElement, 'pre');
 		var codeBlock = preBlock.childNodes.item(0);
-
-		var total = codeBlock.innerHTML.split('\n').length - 1;
+		//Without trimming, additional characters can create new lines
+		//this happens when PrismJS is not applied (in testing)
+		//setting total to length - 1 makes the last not collapsed
+		var total = codeBlock.innerHTML.trim().split('\n').length;
 		var config = getConfig(highlight.getAttribute('line-highlight'), total);
 
 		if (preBlock) {

--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ module.exports = function() {
 		//Without trimming, additional characters can create new lines
 		//this happens when PrismJS is not applied (in testing)
 		//setting total to length - 1 makes the last not collapsed
+		codeBlock.textContent = codeBlock.textContent.trim();
 		var total = codeBlock.innerHTML.split('\n').length;
 		var config = getConfig(highlight.getAttribute('line-highlight'), total);
 

--- a/index.js
+++ b/index.js
@@ -66,14 +66,14 @@ var getConfig = function(lineString, lineCount) {
 					return typeof val === 'number' && !isNaN(val);
 				})
 			;
-			
+
 			if (range[0] > current + padding) {
 				var collapseEnd = (range[0] - 1 - padding);
 				if (collapseEnd !== current) {
 					collapse.push(current + '-' + collapseEnd);
 				}
 			}
-			
+
 			current = (range[1] || range[0]) + padding + 1;
 		}
 
@@ -109,7 +109,9 @@ module.exports = function() {
 		//Without trimming, additional characters can create new lines
 		//this happens when PrismJS is not applied (in testing)
 		//setting total to length - 1 makes the last not collapsed
-		codeBlock.textContent = codeBlock.textContent.trim();
+		if (codeBlock.textContent.slice(-1) === "\n") {
+			codeBlock.textContent = codeBlock.textContent.slice(0, -1);
+		}
 		var total = codeBlock.innerHTML.split('\n').length;
 		var config = getConfig(highlight.getAttribute('line-highlight'), total);
 

--- a/prism-collapse.js
+++ b/prism-collapse.js
@@ -100,7 +100,7 @@ function collapseLines(pre, config) {
 	});
 
 	for (var i = 0; i < inserts.length; i++) {
-		var line = Math.min(code.length - 1, inserts[i][0] - 1);
+		var line = Math.min(code.length, inserts[i][0] - 1);
 
 		code.splice(line, 0, inserts[i][1]);
 		numbers[line] += inserts[i][2];

--- a/prism-collapse.js
+++ b/prism-collapse.js
@@ -92,7 +92,7 @@ function collapseLines(pre, config) {
 
 	var code = codeContainer.innerHTML.split('\n');
 	code = code.map(function(line, index) {
-		if (index === code.length - 1) {
+		if (index === code.length) {
 			return line;
 		}
 
@@ -100,7 +100,7 @@ function collapseLines(pre, config) {
 	});
 
 	for (var i = 0; i < inserts.length; i++) {
-		var line = Math.min(code.length - 1, inserts[i][0] - 1);
+		var line = Math.min(code.length, inserts[i][0] - 1);
 
 		code.splice(line, 0, inserts[i][1]);
 		numbers[line] += inserts[i][2];

--- a/prism-collapse.js
+++ b/prism-collapse.js
@@ -92,7 +92,7 @@ function collapseLines(pre, config) {
 
 	var code = codeContainer.innerHTML.split('\n');
 	code = code.map(function(line, index) {
-		if (index === code.length) {
+		if (index === code.length - 1) {
 			return line;
 		}
 
@@ -100,7 +100,7 @@ function collapseLines(pre, config) {
 	});
 
 	for (var i = 0; i < inserts.length; i++) {
-		var line = Math.min(code.length, inserts[i][0] - 1);
+		var line = Math.min(code.length - 1, inserts[i][0] - 1);
 
 		code.splice(line, 0, inserts[i][1]);
 		numbers[line] += inserts[i][2];

--- a/test-collapse-last-line.md
+++ b/test-collapse-last-line.md
@@ -1,5 +1,3 @@
-You can also set the `value` of the properties of `pageComponentViewModel` and verify that the `routeData` is updated correctly:
-
 ```html
 <div id="mocha"></div>
 <link rel="stylesheet" href="//unpkg.com/mocha@5.2.0/mocha.css">

--- a/test-collapse-last-line.md
+++ b/test-collapse-last-line.md
@@ -1,0 +1,111 @@
+You can also set the `value` of the properties of `pageComponentViewModel` and verify that the `routeData` is updated correctly:
+
+```html
+<div id="mocha"></div>
+<link rel="stylesheet" href="//unpkg.com/mocha@5.2.0/mocha.css">
+<script src="//unpkg.com/mocha@5.2.0/mocha.js" type="text/javascript"></script>
+<script src="//unpkg.com/chai@4.1.2/chai.js" type="text/javascript"></script>
+<script type="module">
+import { Component, route, value, DefineMap } from "can";
+
+// Mocha / Chai Setup
+mocha.setup("bdd")
+var assert = chai.assert;
+
+const HomePage = Component.extend({
+	tag: "home-page",
+
+	view: `
+		<h2>Home Page</h2>
+	`,
+
+	ViewModel: {}
+});
+
+const ListPage = Component.extend({
+	tag: "list-page",
+
+	view: `
+		<h2>List Page</h2>
+		<p>{{ id }}</p>
+	`,
+
+	ViewModel: {
+		id: "number"
+	}
+});
+
+const Application = Component.extend({
+    tag: "app-component",
+
+    ViewModel: {
+		routeData: {
+			default() {
+				route.register("{page}", { page: "home" });
+				route.register("list/{id}", { page: "list" });
+				route.start();
+				return route.data;
+			}
+        },
+
+        get pageComponentViewModel() {
+			const vmData = {};
+
+			if (this.routeData.page === "list") {
+				vmData.id = value.bind(this.routeData, "id");
+			}
+
+			return vmData;
+		},
+
+        get pageComponent() {
+			if (this.routeData.page === "home") {
+				return new HomePage();
+			} else if (this.routeData.page === "list") {
+				return new ListPage({
+					viewModel: this.pageComponentViewModel
+				});
+			}
+		}
+    },
+
+    view: `
+		{{ pageComponent }}
+	`
+});
+
+describe("Application", () => {
+    it("pageComponent viewModel", () => {
+        const routeData = new DefineMap({
+            page: "home",
+            id: null
+        });
+
+        const vm = new Application.ViewModel({
+            routeData: routeData
+		});
+
+		assert.deepEqual(vm.pageComponentViewModel, {}, "viewModelData defaults to empty object");
+
+		routeData.update({
+			page: "list",
+			id: 10
+		});
+
+		const viewModelId = vm.pageComponentViewModel.id;
+		assert.equal(viewModelId.value, 10, "routeData.id is passed to pageComponent viewModel");
+
+		routeData.id = 20;
+
+		assert.equal(viewModelId.value, 20, "setting routeData.id updates the pageComponentViewModel.id");
+
+		viewModelId.value = 30;
+		assert.equal(routeData.id, 30, "setting pageComponentViewModel.id updates routeData.id");
+    });
+});
+
+// start Mocha
+mocha.run();
+</script>
+```
+<span line-highlight='97-100,only'/>

--- a/test-collapse-last-line.md
+++ b/test-collapse-last-line.md
@@ -1,109 +1,15 @@
-```html
-<div id="mocha"></div>
-<link rel="stylesheet" href="//unpkg.com/mocha@5.2.0/mocha.css">
-<script src="//unpkg.com/mocha@5.2.0/mocha.js" type="text/javascript"></script>
-<script src="//unpkg.com/chai@4.1.2/chai.js" type="text/javascript"></script>
-<script type="module">
-import { Component, route, value, DefineMap } from "can";
-
-// Mocha / Chai Setup
-mocha.setup("bdd")
-var assert = chai.assert;
-
-const HomePage = Component.extend({
-	tag: "home-page",
-
-	view: `
-		<h2>Home Page</h2>
-	`,
-
-	ViewModel: {}
+```js
+Todo.List = DefineList.extend("TodoList",{
+    "#": Todo,
+    completeAll(){
+        return this.forEach((todo) => { todo.complete = true; });
+    }
 });
 
-const ListPage = Component.extend({
-	tag: "list-page",
-
-	view: `
-		<h2>List Page</h2>
-		<p>{{ id }}</p>
-	`,
-
-	ViewModel: {
-		id: "number"
-	}
+const todoConnection = restModel({
+    Map: Todo,
+    List: Todo.List,
+    url: "/api/todos/{id}"
 });
-
-const Application = Component.extend({
-    tag: "app-component",
-
-    ViewModel: {
-		routeData: {
-			default() {
-				route.register("{page}", { page: "home" });
-				route.register("list/{id}", { page: "list" });
-				route.start();
-				return route.data;
-			}
-        },
-
-        get pageComponentViewModel() {
-			const vmData = {};
-
-			if (this.routeData.page === "list") {
-				vmData.id = value.bind(this.routeData, "id");
-			}
-
-			return vmData;
-		},
-
-        get pageComponent() {
-			if (this.routeData.page === "home") {
-				return new HomePage();
-			} else if (this.routeData.page === "list") {
-				return new ListPage({
-					viewModel: this.pageComponentViewModel
-				});
-			}
-		}
-    },
-
-    view: `
-		{{ pageComponent }}
-	`
-});
-
-describe("Application", () => {
-    it("pageComponent viewModel", () => {
-        const routeData = new DefineMap({
-            page: "home",
-            id: null
-        });
-
-        const vm = new Application.ViewModel({
-            routeData: routeData
-		});
-
-		assert.deepEqual(vm.pageComponentViewModel, {}, "viewModelData defaults to empty object");
-
-		routeData.update({
-			page: "list",
-			id: 10
-		});
-
-		const viewModelId = vm.pageComponentViewModel.id;
-		assert.equal(viewModelId.value, 10, "routeData.id is passed to pageComponent viewModel");
-
-		routeData.id = 20;
-
-		assert.equal(viewModelId.value, 20, "setting routeData.id updates the pageComponentViewModel.id");
-
-		viewModelId.value = 30;
-		assert.equal(routeData.id, 30, "setting pageComponentViewModel.id updates routeData.id");
-    });
-});
-
-// start Mocha
-mocha.run();
-</script>
 ```
-<span line-highlight='97-100,only'/>
+<span line-highlight='5-7,only'/>

--- a/test.js
+++ b/test.js
@@ -118,8 +118,8 @@ describe("bit-docs-html-highlight-line", function() {
 		}).then(function() {
 			open("index.html",function(browser, close) {
 				var doc = browser.window.document;
-				var collapseCodes = doc.querySelectorAll('pre[data-collapse="1-93,104-106"]');
-				assert.equal(collapseCodes.length,1);
+				var collapseCode = doc.querySelectorAll('pre[data-collapse="1-93,104-107"]');
+				assert.ok(collapseCode);
 				close();
 				done();
 			}, done);

--- a/test.js
+++ b/test.js
@@ -119,6 +119,7 @@ describe("bit-docs-html-highlight-line", function() {
 			open("index.html",function(browser, close) {
 				var doc = browser.window.document;
 				var collapseCode = doc.querySelector('pre[data-collapse="1-93,104-106"]');
+				console.log(collapseCode);
 				assert.ok(collapseCode);
 				close();
 				done();

--- a/test.js
+++ b/test.js
@@ -118,7 +118,7 @@ describe("bit-docs-html-highlight-line", function() {
 		}).then(function() {
 			open("index.html",function(browser, close) {
 				var doc = browser.window.document;
-				var collapseCode = doc.querySelectorAll('pre[data-collapse="1-93,104-106"]');
+				var collapseCode = doc.querySelectorAll('pre[data-collapse="11-12"]');
 				assert.ok(collapseCode);
 				close();
 				done();

--- a/test.js
+++ b/test.js
@@ -118,9 +118,9 @@ describe("bit-docs-html-highlight-line", function() {
 		}).then(function() {
 			open("index.html",function(browser, close) {
 				var doc = browser.window.document;
-				var collapseCode = doc.querySelector('pre[data-collapse="1-93,104-106"]');
-				console.log(collapseCode);
-				assert.ok(collapseCode);
+				var collapseCodes = doc.querySelectorAll('pre[data-collapse]');
+				console.log(collapseCodes);
+				assert.ok(collapseCodes);
 				close();
 				done();
 			}, done);

--- a/test.js
+++ b/test.js
@@ -93,7 +93,7 @@ describe("bit-docs-html-highlight-line", function() {
 
 	});
 
-	it.only("Collapse last line", function(done) {
+	it("Collapse last line", function(done) {
 		this.timeout(60000);
 
 		var docMap = Promise.resolve({
@@ -118,7 +118,7 @@ describe("bit-docs-html-highlight-line", function() {
 		}).then(function() {
 			open("index.html",function(browser, close) {
 				var doc = browser.window.document;
-				var collapseCode = doc.querySelectorAll('pre[data-collapse="1-93,104-107"]');
+				var collapseCode = doc.querySelectorAll('pre[data-collapse="1-93,104-106"]');
 				assert.ok(collapseCode);
 				close();
 				done();

--- a/test.js
+++ b/test.js
@@ -118,8 +118,8 @@ describe("bit-docs-html-highlight-line", function() {
 		}).then(function() {
 			open("index.html",function(browser, close) {
 				var doc = browser.window.document;
-				var collapseCodes = doc.querySelectorAll('pre[data-collapse="1-93,104-106"]');
-				assert.equal(collapseCodes.length, 1);
+				var collapseCode = doc.querySelector('pre[data-collapse="1-93,104-106"]');
+				assert.ok(collapseCode);
 				close();
 				done();
 			}, done);

--- a/test.js
+++ b/test.js
@@ -89,7 +89,40 @@ describe("bit-docs-html-highlight-line", function() {
 				close();
 				done();
 			}, done);
-		}, done)
+		}, done);
 
 	});
+
+	it("Collappse last line", function(done) {
+		this.timeout(60000);
+
+		var docMap = Promise.resolve({
+			index: {
+				name: "index",
+				demo: "path/to/demo.html",
+				body: fs.readFileSync(__dirname+"/test-collapse-last-line.md", "utf8")
+			}
+		});
+
+		generate(docMap, {
+			html: {
+				dependencies: {
+					"bit-docs-html-highlight-line": __dirname
+				}
+			},
+			dest: path.join(__dirname, "temp"),
+			parent: "index",
+			forceBuild: true,
+			debug: true,
+			minifyBuild: false
+		}).then(function() {
+			open("index.html",function(browser, close) {
+				var doc = browser.window.document;
+				var collapseCodes = doc.querySelectorAll('pre[data-collapse="1-93,104-106"]');
+				assert.equal(collapseCodes.length, 1);
+				close();
+				done();
+			}, done);
+		}, done);
+	})
 });

--- a/test.js
+++ b/test.js
@@ -93,7 +93,7 @@ describe("bit-docs-html-highlight-line", function() {
 
 	});
 
-	it("Collappse last line", function(done) {
+	it.only("Collapse last line", function(done) {
 		this.timeout(60000);
 
 		var docMap = Promise.resolve({
@@ -118,12 +118,11 @@ describe("bit-docs-html-highlight-line", function() {
 		}).then(function() {
 			open("index.html",function(browser, close) {
 				var doc = browser.window.document;
-				var collapseCodes = doc.querySelectorAll('pre[data-collapse]');
-				console.log(collapseCodes);
-				assert.ok(collapseCodes);
+				var collapseCodes = doc.querySelectorAll('pre[data-collapse="1-93,104-106"]');
+				assert.equal(collapseCodes.length,1);
 				close();
 				done();
 			}, done);
 		}, done);
-	})
+	});
 });


### PR DESCRIPTION
Trim code to prevent creating new line which causes to display one line after the expand button.

### The logic:

- Remove subtracting `1` from the code length
- Trim the the code to prevent additional characters from creating additional new lines, because before applying `PrismJS` additional line is created because of `"` character at the end of the code, that's why `total` was set to `codeLines.length - 1` which makes one line (the last line of the code mostly) visible after the expand button.

With this fix the same number of line of code is present before and after applying `PrismJS`.

Fixes #14 